### PR TITLE
Add basic functionality for a year picker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "calendar-vue",
       "version": "0.1.1",
       "dependencies": {
-        "@types/node-fetch": "^3.0.3",
         "axios": "^0.24.0",
         "bootstrap": "^4.6.0",
         "bootstrap-vue": "^2.21.2",
@@ -17,7 +16,8 @@
         "vue-class-component": "^7.2.6",
         "vue-property-decorator": "^9.1.2",
         "vue-router": "^3.5.3",
-        "vuex": "^3.6.2"
+        "vuex": "^3.6.2",
+        "vuex-class": "^0.3.2"
       },
       "devDependencies": {
         "@types/cypress": "^1.1.3",
@@ -2491,15 +2491,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.2.tgz",
       "integrity": "sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww==",
       "dev": true
-    },
-    "node_modules/@types/node-fetch": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-3.0.3.tgz",
-      "integrity": "sha512-HhggYPH5N+AQe/OmN6fmhKmRRt2XuNJow+R3pQwJxOOF9GuwM7O2mheyGeIrs5MOIeNjDEdgdoyHBOrFeJBR3g==",
-      "deprecated": "This is a stub types definition. node-fetch provides its own type definitions, so you do not need this installed.",
-      "dependencies": {
-        "node-fetch": "*"
-      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.0",
@@ -7864,14 +7855,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
-      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/data-urls": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
@@ -9988,27 +9971,6 @@
       "dev": true,
       "dependencies": {
         "pend": "~1.2.0"
-      }
-    },
-    "node_modules/fetch-blob": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.3.tgz",
-      "integrity": "sha512-ax1Y5I9w+9+JiM+wdHkhBoxew+zG4AJ2SvAD1v1szpddUIiPERVGBxrMcB2ZqW0Y3PP8bOWYv2zqQq1Jp2kqUQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "dependencies": {
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/figgy-pudding": {
@@ -16184,22 +16146,6 @@
         "node": ">= 0.4.6"
       }
     },
-    "node_modules/node-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.0.0.tgz",
-      "integrity": "sha512-bKMI+C7/T/SPU1lKnbQbwxptpCrG9ashG+VkytmXCPZyuM9jB6VU+hY0oi4lC8LxTtAeWdckNCTa3nrGsAdA3Q==",
-      "dependencies": {
-        "data-uri-to-buffer": "^3.0.1",
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
     "node_modules/node-forge": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
@@ -22137,6 +22083,16 @@
         "vue": "^2.0.0"
       }
     },
+    "node_modules/vuex-class": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/vuex-class/-/vuex-class-0.3.2.tgz",
+      "integrity": "sha512-m0w7/FMsNcwJgunJeM+wcNaHzK2KX1K1rw2WUQf7Q16ndXHo7pflRyOV/E8795JO/7fstyjH3EgqBI4h4n4qXQ==",
+      "peerDependencies": {
+        "vue": "^2.5.0",
+        "vue-class-component": "^6.0.0 || ^7.0.0",
+        "vuex": "^3.0.0"
+      }
+    },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
@@ -22386,14 +22342,6 @@
       "dev": true,
       "dependencies": {
         "defaults": "^1.0.3"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
-      "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {
@@ -25495,14 +25443,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.2.tgz",
       "integrity": "sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww==",
       "dev": true
-    },
-    "@types/node-fetch": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-3.0.3.tgz",
-      "integrity": "sha512-HhggYPH5N+AQe/OmN6fmhKmRRt2XuNJow+R3pQwJxOOF9GuwM7O2mheyGeIrs5MOIeNjDEdgdoyHBOrFeJBR3g==",
-      "requires": {
-        "node-fetch": "*"
-      }
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -29858,11 +29798,6 @@
         "assert-plus": "^1.0.0"
       }
     },
-    "data-uri-to-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
-      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og=="
-    },
     "data-urls": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
@@ -31564,14 +31499,6 @@
       "dev": true,
       "requires": {
         "pend": "~1.2.0"
-      }
-    },
-    "fetch-blob": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.3.tgz",
-      "integrity": "sha512-ax1Y5I9w+9+JiM+wdHkhBoxew+zG4AJ2SvAD1v1szpddUIiPERVGBxrMcB2ZqW0Y3PP8bOWYv2zqQq1Jp2kqUQ==",
-      "requires": {
-        "web-streams-polyfill": "^3.0.3"
       }
     },
     "figgy-pudding": {
@@ -36403,15 +36330,6 @@
       "requires": {
         "clone": "2.x",
         "lodash": "^4.17.15"
-      }
-    },
-    "node-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.0.0.tgz",
-      "integrity": "sha512-bKMI+C7/T/SPU1lKnbQbwxptpCrG9ashG+VkytmXCPZyuM9jB6VU+hY0oi4lC8LxTtAeWdckNCTa3nrGsAdA3Q==",
-      "requires": {
-        "data-uri-to-buffer": "^3.0.1",
-        "fetch-blob": "^3.1.2"
       }
     },
     "node-forge": {
@@ -41258,6 +41176,12 @@
       "integrity": "sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==",
       "requires": {}
     },
+    "vuex-class": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/vuex-class/-/vuex-class-0.3.2.tgz",
+      "integrity": "sha512-m0w7/FMsNcwJgunJeM+wcNaHzK2KX1K1rw2WUQf7Q16ndXHo7pflRyOV/E8795JO/7fstyjH3EgqBI4h4n4qXQ==",
+      "requires": {}
+    },
     "w3c-hr-time": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
@@ -41472,11 +41396,6 @@
       "requires": {
         "defaults": "^1.0.3"
       }
-    },
-    "web-streams-polyfill": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
-      "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA=="
     },
     "webidl-conversions": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -59,9 +59,7 @@
     "parserOptions": {
       "ecmaVersion": 2020
     },
-    "rules": {
-      "no-plusplus": 0
-    },
+    "rules": {},
     "overrides": [
       {
         "files": [

--- a/package.json
+++ b/package.json
@@ -59,7 +59,9 @@
     "parserOptions": {
       "ecmaVersion": 2020
     },
-    "rules": {},
+    "rules": {
+      "no-lonely-if": 0
+    },
     "overrides": [
       {
         "files": [

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "vue-class-component": "^7.2.6",
     "vue-property-decorator": "^9.1.2",
     "vue-router": "^3.5.3",
-    "vuex": "^3.6.2"
+    "vuex": "^3.6.2",
+    "vuex-class": "^0.3.2"
   },
   "devDependencies": {
     "@types/cypress": "^1.1.3",
@@ -59,7 +60,7 @@
       "ecmaVersion": 2020
     },
     "rules": {
-      "no-lonely-if": 0
+      "no-plusplus": 0
     },
     "overrides": [
       {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
-    "@types/node-fetch": "^3.0.3",
     "axios": "^0.24.0",
     "bootstrap": "^4.6.0",
     "bootstrap-vue": "^2.21.2",

--- a/src/components/YearPicker.vue
+++ b/src/components/YearPicker.vue
@@ -2,20 +2,11 @@
 <div class="container outer">
   <div class="container box">
     <p class="year">{{ this.currentYear }}</p>
-    <button class="btn btn-primary float-left" @click="decrement()" v-if="this.currentYear >= 1901">
-      &lt; {{ this.getPreviousYear }}
+    <button class="btn btn-primary float-left" :disabled="isLowerLimit" @click="decrement()">
+      &lt; {{ this.previousYear }}
     </button>
-    <button v-else class="btn btn-disabled">
-      &lt; {{ this.getPreviousYear }}
-    </button>
-    <button class="btn btn-primary float-right"
-      @click="increment()"
-      v-if="this.currentYear <= 2049"
-    >
-      {{ this.getNextYear }} &gt;
-    </button>
-    <button v-else class="btn btn-disabled float-right">
-      &gt; {{ this.getNextYear }}
+    <button class="btn btn-primary float-right" :disabled="isUpperLimit" @click="increment()">
+      {{ this.nextYear }} &gt;
     </button>
   </div>
 </div>
@@ -31,9 +22,13 @@ import { State as StateType } from '@/types';
 export default class YearPicker extends Vue {
   @State currentYear!: StateType['currentYear'];
 
-  @Getter getPreviousYear!: number;
+  @Getter previousYear!: number;
 
-  @Getter getNextYear!: number;
+  @Getter nextYear!: number;
+
+  @Getter isUpperLimit!: boolean;
+
+  @Getter isLowerLimit!: boolean;
 
   @Action increment!: ActionContext<StateType, StateType>;
 

--- a/src/components/YearPicker.vue
+++ b/src/components/YearPicker.vue
@@ -1,0 +1,62 @@
+<template>
+<div class="container outer">
+  <div class="container box">
+    <p class="year">{{ this.year }}</p>
+    <button class="btn btn-primary float-left" @click="onClick($event, mode=true)">
+      &lt; {{ this.prevYear }}
+    </button>
+    <button class="btn btn-primary float-right" @click="onClick($event, mode=false)">
+      {{ this.nextYear }} &gt;
+    </button>
+  </div>
+</div>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator';
+
+@Component
+export default class YearPicker extends Vue {
+  public year: number = new Date().getFullYear();
+
+  public prevYear: number = this.year - 1;
+
+  public nextYear: number = this.year + 1;
+
+  onClick(event: Event | undefined, mode: boolean): void {
+    // if true; previous year button is clicked
+    if (mode === true) {
+      if (this.year > 1900) {
+        this.year -= 1;
+        this.prevYear -= 1;
+        this.nextYear -= 1;
+      }
+    } else if (mode === false) {
+      if (this.year < 2050) {
+        this.year += 1;
+        this.prevYear += 1;
+        this.nextYear += 1;
+      }
+    }
+  }
+}
+</script>
+
+<style scoped>
+.outer {
+  padding-top: 1%;
+  padding-bottom: 1%;
+}
+
+.box {
+  padding-top: 1%;
+  padding-bottom: 1%;
+  border: 1px solid gray;
+  overflow: hidden;
+}
+
+.year {
+  font-size: 150%;
+  text-align: center;
+}
+</style>

--- a/src/components/YearPicker.vue
+++ b/src/components/YearPicker.vue
@@ -1,12 +1,21 @@
 <template>
 <div class="container outer">
   <div class="container box">
-    <p class="year">{{ this.year }}</p>
-    <button class="btn btn-primary float-left" @click="onClick($event, mode=true)">
-      &lt; {{ this.prevYear }}
+    <p class="year">{{ this.currentYear }}</p>
+    <button class="btn btn-primary float-left" @click="decrement()" v-if="this.currentYear >= 1901">
+      &lt; {{ this.getPreviousYear }}
     </button>
-    <button class="btn btn-primary float-right" @click="onClick($event, mode=false)">
-      {{ this.nextYear }} &gt;
+    <button v-else class="btn btn-disabled">
+      &lt; {{ this.getPreviousYear }}
+    </button>
+    <button class="btn btn-primary float-right"
+      @click="increment()"
+      v-if="this.currentYear <= 2049"
+    >
+      {{ this.getNextYear }} &gt;
+    </button>
+    <button v-else class="btn btn-disabled float-right">
+      &gt; {{ this.getNextYear }}
     </button>
   </div>
 </div>
@@ -14,31 +23,19 @@
 
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
+import { Action, Getter, State } from 'vuex-class';
 
 @Component
 export default class YearPicker extends Vue {
-  public year: number = new Date().getFullYear();
+  @State currentYear: any;
 
-  public prevYear: number = this.year - 1;
+  @Getter getPreviousYear: any;
 
-  public nextYear: number = this.year + 1;
+  @Getter getNextYear: any;
 
-  onClick(event: Event | undefined, mode: boolean): void {
-    // if true; previous year button is clicked
-    if (mode === true) {
-      if (this.year > 1900) {
-        this.year -= 1;
-        this.prevYear -= 1;
-        this.nextYear -= 1;
-      }
-    } else if (mode === false) {
-      if (this.year < 2050) {
-        this.year += 1;
-        this.prevYear += 1;
-        this.nextYear += 1;
-      }
-    }
-  }
+  @Action increment: any;
+
+  @Action decrement: any;
 }
 </script>
 

--- a/src/components/YearPicker.vue
+++ b/src/components/YearPicker.vue
@@ -24,18 +24,20 @@
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 import { Action, Getter, State } from 'vuex-class';
+import { ActionContext } from 'vuex';
+import { State as StateType } from '@/types';
 
 @Component
 export default class YearPicker extends Vue {
-  @State currentYear: any;
+  @State currentYear!: StateType['currentYear'];
 
-  @Getter getPreviousYear: any;
+  @Getter getPreviousYear!: number;
 
-  @Getter getNextYear: any;
+  @Getter getNextYear!: number;
 
-  @Action increment: any;
+  @Action increment!: ActionContext<StateType, StateType>;
 
-  @Action decrement: any;
+  @Action decrement!: ActionContext<StateType, StateType>;
 }
 </script>
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import Vuex, { ActionContext } from 'vuex';
+import Vuex from 'vuex';
 // import { State } from '../types';
 import year from './year';
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,6 +1,5 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
-// import { State } from '../types';
 import year from './year';
 
 Vue.use(Vuex);

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,32 +1,8 @@
 import Vue from 'vue';
 import Vuex, { ActionContext } from 'vuex';
-import { State } from '../types';
+// import { State } from '../types';
+import year from './year';
 
 Vue.use(Vuex);
 
-export default new Vuex.Store({
-  state: {
-    currentYear: new Date().getFullYear(),
-  },
-  getters: {
-    getPreviousYear: (state: State) => state.currentYear - 1,
-    getNextYear: (state: State) => state.currentYear + 1,
-  },
-  modules: {},
-  mutations: {
-    increment(state: State) {
-      state.currentYear++;
-    },
-    decrement(state: State) {
-      state.currentYear--;
-    },
-  },
-  actions: {
-    increment(ctx: ActionContext<State, State>) {
-      ctx.commit('increment');
-    },
-    decrement(ctx: ActionContext<State, State>) {
-      ctx.commit('decrement');
-    },
-  },
-});
+export default new Vuex.Store(year);

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,15 +1,32 @@
 import Vue from 'vue';
-import Vuex from 'vuex';
+import Vuex, { ActionContext } from 'vuex';
+import { State } from '../types';
 
 Vue.use(Vuex);
 
 export default new Vuex.Store({
   state: {
+    currentYear: new Date().getFullYear(),
   },
+  getters: {
+    getPreviousYear: (state: State) => state.currentYear - 1,
+    getNextYear: (state: State) => state.currentYear + 1,
+  },
+  modules: {},
   mutations: {
+    increment(state: State) {
+      state.currentYear++;
+    },
+    decrement(state: State) {
+      state.currentYear--;
+    },
   },
   actions: {
-  },
-  modules: {
+    increment(ctx: ActionContext<State, State>) {
+      ctx.commit('increment');
+    },
+    decrement(ctx: ActionContext<State, State>) {
+      ctx.commit('decrement');
+    },
   },
 });

--- a/src/store/year.ts
+++ b/src/store/year.ts
@@ -6,16 +6,19 @@ export default {
     currentYear: new Date().getFullYear(),
   },
   getters: {
-    getPreviousYear: (state: State): number => state.currentYear - 1,
-    getNextYear: (state: State): number => state.currentYear + 1,
+    previousYear: (state: State): number => state.currentYear - 1,
+    nextYear: (state: State): number => state.currentYear + 1,
+    isLowerLimit: (state: State): boolean => !!(state.currentYear < 1901),
+    isUpperLimit: (state: State): boolean => !!(state.currentYear > 2049),
   },
   modules: {},
   mutations: {
     increment(state: State): void {
-      state.currentYear++;
+      state.currentYear += 1;
     },
+
     decrement(state: State): void {
-      state.currentYear--;
+      state.currentYear -= 1;
     },
   },
   actions: {

--- a/src/store/year.ts
+++ b/src/store/year.ts
@@ -6,8 +6,8 @@ export default {
     currentYear: new Date().getFullYear(),
   },
   getters: {
-    getPreviousYear: (state: State) => state.currentYear - 1,
-    getNextYear: (state: State) => state.currentYear + 1,
+    getPreviousYear: (state: State): number => state.currentYear - 1,
+    getNextYear: (state: State): number => state.currentYear + 1,
   },
   modules: {},
   mutations: {

--- a/src/store/year.ts
+++ b/src/store/year.ts
@@ -11,18 +11,18 @@ export default {
   },
   modules: {},
   mutations: {
-    increment(state: State) {
+    increment(state: State): void {
       state.currentYear++;
     },
-    decrement(state: State) {
+    decrement(state: State): void {
       state.currentYear--;
     },
   },
   actions: {
-    increment(ctx: ActionContext<State, State>) {
+    increment(ctx: ActionContext<State, State>): void {
       ctx.commit('increment');
     },
-    decrement(ctx: ActionContext<State, State>) {
+    decrement(ctx: ActionContext<State, State>): void {
       ctx.commit('decrement');
     },
   },

--- a/src/store/year.ts
+++ b/src/store/year.ts
@@ -1,0 +1,29 @@
+import { ActionContext } from 'vuex';
+import { State } from '@/types';
+
+export default {
+  state: {
+    currentYear: new Date().getFullYear(),
+  },
+  getters: {
+    getPreviousYear: (state: State) => state.currentYear - 1,
+    getNextYear: (state: State) => state.currentYear + 1,
+  },
+  modules: {},
+  mutations: {
+    increment(state: State) {
+      state.currentYear++;
+    },
+    decrement(state: State) {
+      state.currentYear--;
+    },
+  },
+  actions: {
+    increment(ctx: ActionContext<State, State>) {
+      ctx.commit('increment');
+    },
+    decrement(ctx: ActionContext<State, State>) {
+      ctx.commit('decrement');
+    },
+  },
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,3 @@
+export interface State {
+    currentYear: number;
+}

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="home">
     <Header />
+    <YearPicker />
     <Calendar />
     <Footer />
   </div>
@@ -12,12 +13,14 @@ import { Component, Vue } from 'vue-property-decorator';
 import Header from '@/components/Header.vue';
 import Calendar from '@/components/Calendar.vue';
 import Footer from '@/components/Footer.vue';
+import YearPicker from '@/components/YearPicker.vue';
 
 @Component({
   components: {
     Header,
     Calendar,
     Footer,
+    YearPicker,
   },
 })
 export default class Home extends Vue {}

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -1,6 +1,7 @@
-import Vue from 'vue';
 import { mount, Wrapper } from '@vue/test-utils';
 import BootstrapVue from 'bootstrap-vue';
+import Vuex from 'vuex';
+import Vue from 'vue';
 
 // components
 import Home from '@/views/Home.vue';
@@ -9,12 +10,17 @@ import Calendar from '@/components/Calendar.vue';
 import Footer from '@/components/Footer.vue';
 import YearPicker from '@/components/YearPicker.vue';
 
+// Store
+import yearStore from '@/store/year';
+
 // plugins
 Vue.use(BootstrapVue);
+Vue.use(Vuex);
+const store = new Vuex.Store(yearStore);
 
 describe('Home.vue', (): void => {
   it('renders all components', (): void => {
-    const wrapper: Wrapper<Home> = mount(Home);
+    const wrapper: Wrapper<Home> = mount(Home, { store });
 
     expect(wrapper.findComponent(Header)).not.toBeNull();
     expect(wrapper.findComponent(YearPicker)).not.toBeNull();

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -7,6 +7,7 @@ import Home from '@/views/Home.vue';
 import Header from '@/components/Header.vue';
 import Calendar from '@/components/Calendar.vue';
 import Footer from '@/components/Footer.vue';
+import YearPicker from '@/components/YearPicker.vue';
 
 // plugins
 Vue.use(BootstrapVue);
@@ -16,6 +17,7 @@ describe('Home.vue', (): void => {
     const wrapper: Wrapper<Home> = mount(Home);
 
     expect(wrapper.findComponent(Header)).not.toBeNull();
+    expect(wrapper.findComponent(YearPicker)).not.toBeNull();
     expect(wrapper.findComponent(Calendar)).not.toBeNull();
     expect(wrapper.findComponent(Footer)).not.toBeNull();
   });


### PR DESCRIPTION
# What does this PR Fix?
- Adds a basic functionality for a user to choose the year
- Has two buttons, one for the previous year and one for the next year

# Proposed Changes
- Add `components/YearPicker.vue` for this component
- Add an ESLint rule to disable `no-lonely-if`

# Additional Info
- This **does not** implement the dropdown menu to select the year manually
- The upper limit for the year is **2050**
- The lower limit for the year is **1900**
- The UI is pretty much bare-bones so here is a list of things to fix:
   - Bring the buttons back to the position of the year displayed in the middle
   - Add subtle rounded corners to the box
   - Probably change the design of the button as it looks very bootstrap-y
   - Make the year on the center clickable (a link?) so that we can pass an `@click` handler to show the dropdown

# Screenshots
<img width="1370" alt="image" src="https://user-images.githubusercontent.com/66675022/141670853-182dbbf7-9e8a-4c3e-a3fe-b3bc4599cb24.png">
<img width="1165" alt="image" src="https://user-images.githubusercontent.com/66675022/141670863-7799f0dd-378f-4e9c-bceb-85a0b2834735.png">
<img width="1181" alt="image" src="https://user-images.githubusercontent.com/66675022/141670896-418075d1-3e40-467f-ab31-033d2f64893f.png">

- [x] Have you tested this code?
